### PR TITLE
feat: enforce string-only state references

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ Building complex stateful applications is hard. Traditional state management oft
 - 🧪 **Battle Tested** - Comprehensive test suite with real-world scenarios
 - 📚 **Extensive Documentation** - Examples for every feature
 - 🔧 **Framework Agnostic** - Works with React, Vue, Angular, Svelte, or vanilla JS
-- 🎨 **Built-in Visualization** - Generate Mermaid diagrams with browser preview
+- 🎨 **Built-in Visualization** - Generate Mermaid diagrams for documentation
 
 ## Installation
 
@@ -74,10 +74,10 @@ const machine = createMachine('toggle')
 const off = machine.state('off')
 const on = machine.state('on')
 
-off.on('TOGGLE', on)
-on.on('TOGGLE', off)
+off.on('TOGGLE', 'on')
+on.on('TOGGLE', 'off')
 
-machine.initial(off)
+machine.initial('off')
 
 // Start the machine
 const toggle = machine.start()
@@ -111,11 +111,11 @@ const increment = ctx => {
   console.log(`Count: ${ctx.count}`)
 }
 
-idle.on('START', counting).do(increment)
+idle.on('START', 'counting').do(increment)
 
-counting.on('INCREMENT', counting).do(increment).on('STOP', idle)
+counting.on('INCREMENT', 'counting').do(increment).on('STOP', 'idle')
 
-machine.initial(idle)
+machine.initial('idle')
 
 // Start with initial context
 const counter = machine.start({ count: 0 })
@@ -158,14 +158,15 @@ const playing = machine.state('playing')
 const normal = playing.state('normal')
 const fastForward = playing.state('fast-forward')
 
-stopped.on('PLAY', normal)
-normal.on('FF', fastForward)
-playing.on('STOP', stopped)
+stopped.on('PLAY', 'normal')
+normal.on('FF', 'fast-forward')
+playing.on('STOP', 'stopped')
 
-machine.initial(stopped)
+machine.initial('stopped')
 
-// Generates clean hierarchical diagram
-await machine.visualizer().preview()
+// Generate Mermaid diagram
+const diagram = machine.visualizer().visualize()
+console.log(diagram)
 ```
 
 ### Current State Highlighting
@@ -196,7 +197,7 @@ const loading = machine.state('loading')
 const success = machine.state('success')
 const error = machine.state('error')
 
-idle.on('FETCH', loading)
+idle.on('FETCH', 'loading')
 
 loading
   .enter(async ctx => {
@@ -208,13 +209,13 @@ loading
       ctx.instance.send('ERROR')
     }
   })
-  .on('SUCCESS', success)
-  .on('ERROR', error)
+  .on('SUCCESS', 'success')
+  .on('ERROR', 'error')
 
-error.on('RETRY', loading)
-success.on('REFRESH', loading)
+error.on('RETRY', 'loading')
+success.on('REFRESH', 'loading')
 
-machine.initial(idle)
+machine.initial('idle')
 
 const fetcher = machine.start({
   url: 'https://api.example.com/data',
@@ -248,24 +249,24 @@ const dashboard = auth.state('dashboard')
 const profile = auth.state('profile')
 
 // Set initial states
-unauth.initial(login)
-auth.initial(dashboard)
+unauth.initial('login')
+auth.initial('dashboard')
 
 // Transitions between child states
-login.on('REGISTER', register).on('FORGOT_PASSWORD', forgotPassword)
+login.on('REGISTER', 'register').on('FORGOT_PASSWORD', 'forgot-password')
 
-register.on('BACK', login)
-forgotPassword.on('BACK', login)
+register.on('BACK', 'login')
+forgotPassword.on('BACK', 'login')
 
 // Transitions between parent states
-unauth.on('LOGIN_SUCCESS', auth)
-auth.on('LOGOUT', unauth)
+unauth.on('LOGIN_SUCCESS', 'authenticated')
+auth.on('LOGOUT', 'unauthenticated')
 
 // Navigation within authenticated state
-dashboard.on('VIEW_PROFILE', profile)
-profile.on('BACK', dashboard)
+dashboard.on('VIEW_PROFILE', 'profile')
+profile.on('BACK', 'dashboard')
 
-machine.initial(unauth)
+machine.initial('unauthenticated')
 
 const app = machine.start()
 console.log(app.current) // 'unauthenticated.login'
@@ -279,7 +280,7 @@ const machine = createMachine('notification')
 const idle = machine.state('idle')
 const showing = machine.state('showing')
 
-idle.on('SHOW', showing).fire(async (ctx, event) => {
+idle.on('SHOW', 'showing').fire(async (ctx, event) => {
   // Non-blocking analytics call
   await analytics.track('notification_shown', {
     message: event.payload.message
@@ -290,7 +291,7 @@ showing
   .enter((ctx, event) => {
     ctx.message = event.payload.message
   })
-  .on('DISMISS', idle)
+  .on('DISMISS', 'idle')
   .fire(async () => {
     // Non-blocking cleanup
     await api.markAsRead()
@@ -310,11 +311,11 @@ const reviewing = machine.state('reviewing')
 const submitting = machine.state('submitting')
 const success = machine.state('success')
 
-editing.on('CONTINUE', reviewing).if(ctx => ctx.form.isValid) // Only transition if form is valid
+editing.on('CONTINUE', 'reviewing').if(ctx => ctx.form.isValid) // Only transition if form is valid
 
 reviewing
-  .on('BACK', editing)
-  .on('SUBMIT', submitting)
+  .on('BACK', 'editing')
+  .on('SUBMIT', 'submitting')
   .if(ctx => ctx.form.agreeToTerms) // Must agree to terms
 
 submitting
@@ -322,7 +323,7 @@ submitting
     await api.submitForm(ctx.form)
     ctx.instance.send('SUCCESS')
   })
-  .on('SUCCESS', success)
+  .on('SUCCESS', 'success')
 ```
 
 ### Traffic Light with Timers
@@ -342,7 +343,7 @@ red
     }, 3000) // 3 seconds
   })
   .exit(ctx => clearTimeout(ctx.timer))
-  .on('NEXT', green)
+  .on('NEXT', 'green')
 
 green
   .enter(ctx => {
@@ -351,7 +352,7 @@ green
     }, 3000)
   })
   .exit(ctx => clearTimeout(ctx.timer))
-  .on('NEXT', yellow)
+  .on('NEXT', 'yellow')
 
 yellow
   .enter(ctx => {
@@ -360,9 +361,9 @@ yellow
     }, 1000) // 1 second
   })
   .exit(ctx => clearTimeout(ctx.timer))
-  .on('NEXT', red)
+  .on('NEXT', 'red')
 
-machine.initial(red)
+machine.initial('red')
 ```
 
 ## Advanced Patterns
@@ -378,7 +379,7 @@ const normal = machine.state('normal')
 const emergency = machine.state('emergency')
 
 // Handle emergency from any state
-machine.on('EMERGENCY', emergency).do(ctx => {
+machine.on('EMERGENCY', 'emergency').do(ctx => {
   ctx.previousState = ctx.instance.current
 })
 
@@ -523,12 +524,12 @@ const editing = machine.state('editing')
 const preview = machine.state('preview')
 const published = machine.state('published')
 
-editing.on('preview', preview)
-preview.on('edit', editing)
-preview.on('publish', published)
-published.on('edit', editing)
+editing.on('preview', 'preview')
+preview.on('edit', 'editing')
+preview.on('publish', 'published')
+published.on('edit', 'editing')
 
-machine.initial(editing)
+machine.initial('editing')
 
 // Start with history enabled
 const editor = machine.start(
@@ -627,7 +628,7 @@ See [RELEASE.md](./RELEASE.md) for the complete user guide.
 const machine = createMachine('name')
 const state = machine.state('stateName')
 const childState = parentState.state('childName')
-machine.initial(state)
+machine.initial('stateName')
 ```
 
 ### State Configuration
@@ -636,7 +637,7 @@ machine.initial(state)
 state
   .enter((ctx, event) => {}) // Entry action
   .exit((ctx, event) => {}) // Exit action
-  .on('EVENT', targetState) // Transition
+  .on('EVENT', 'targetState') // Transition
   .do((ctx, event) => {}) // Transition action
   .if((ctx, event) => true) // Guard condition
   .fire((ctx, event) => {}) // Fire-and-forget action

--- a/docs/README.md
+++ b/docs/README.md
@@ -201,7 +201,8 @@ console.log(instance.current);  // Current state ID
 console.log(instance.context);  // Current context
 
 // Visualize the machine
-await machine.visualizer().preview();
+const diagram = machine.visualizer().visualize()
+console.log(diagram);
 ```
 
 ## License

--- a/docs/api.md
+++ b/docs/api.md
@@ -117,20 +117,35 @@ Sets the default child state. When entering a parent state, the machine automati
 auth.initial('login'); // When entering 'auth', also enter 'auth.login'
 ```
 
-### Parent State References
+### Relative State Navigation
 
-Use `^` notation to reference parent states in transitions:
+Use relative path notation to reference states relative to the current state:
 
 ```javascript
 // Go to parent state
 loginForm.on('CANCEL', '^');
 
-// Go to grandparent state
+// Go to grandparent state (two levels up)
 deepChild.on('HOME', '^^');
 
-// Go to sibling via parent
+// Go to great-grandparent (three levels up)
+deeplyNested.on('TOP', '^^^');
+
+// Go to sibling (parent's child)
 login.on('REGISTER', '^.register');
+
+// Go to cousin (grandparent's descendant)
+deepChild.on('COUSIN', '^^.otherParent.cousin');
+
+// Note: ^.^ is NOT valid syntax - use ^^ instead
 ```
+
+**Path Resolution:**
+- `^` - Navigate to parent state
+- `^^` - Navigate to grandparent (NOT `^.^`)
+- `^^^` - Navigate to great-grandparent
+- `^.sibling` - Navigate to parent, then to its child named 'sibling'
+- `^^.uncle.cousin` - Navigate to grandparent, then through its descendants
 
 ## State Lifecycle
 
@@ -176,27 +191,23 @@ loading
 
 ## Transitions
 
-### `state.on(event: string, target: State | string | Function): Transition`
+### `state.on(event: string, target: string | Function): Transition`
 
 Defines a transition from this state to another when an event occurs.
 
 **Parameters:**
 - `event` - Event name that triggers the transition
-- `target` - Target state (can be State instance, state ID, or function)
+- `target` - Target state ID or function returning state ID
 
 **Returns:** A `Transition` instance for chaining modifiers
 
 **Target Types:**
-- **State instance:** `on('EVENT', targetState)`
-- **State ID:** `on('EVENT', 'targetId')`
-- **Dynamic target:** `on('EVENT', (ctx, event) => ctx.premium ? 'premium' : 'basic')`
-- **Parent reference:** `on('EVENT', '^')` or `on('EVENT', '^^')`
+- **State ID:** `on('EVENT', 'targetId')` - Simple string reference
+- **Dynamic target:** `on('EVENT', (ctx, event) => ctx.premium ? 'premium' : 'basic')` - Function returning string
+- **Parent reference:** `on('EVENT', '^')` or `on('EVENT', '^^')` - Relative navigation
 
 **Example:**
 ```javascript
-// Direct state reference
-idle.on('START', loading);
-
 // State ID
 idle.on('START', 'loading');
 

--- a/docs/concepts.md
+++ b/docs/concepts.md
@@ -21,7 +21,7 @@ const loading = machine.state('loading');
 Transitions define how your machine moves from one state to another in response to events.
 
 ```javascript
-idle.on('FETCH', loading);  // When FETCH event occurs, go from idle to loading
+idle.on('FETCH', 'loading');  // When FETCH event occurs, go from idle to loading
 ```
 
 ## Events

--- a/docs/examples/angular-integration.md
+++ b/docs/examples/angular-integration.md
@@ -94,17 +94,17 @@ export class AuthComponent implements OnInit {
     const authenticating = machine.state('authenticating');
     const loggedIn = machine.state('loggedIn');
 
-    loggedOut.on('LOGIN', authenticating);
+    loggedOut.on('LOGIN', 'authenticating');
 
     authenticating
-      .on('SUCCESS', loggedIn)
+      .on('SUCCESS', 'loggedIn')
       .do(async (ctx, event) => {
         const user = await this.authService.login(event.email, event.password);
         ctx.user = user;
       })
-      .on('ERROR', loggedOut);
+      .on('ERROR', 'loggedOut');
 
-    loggedIn.on('LOGOUT', loggedOut);
+    loggedIn.on('LOGOUT', 'loggedOut');
 
     machine.initial('loggedOut');
 

--- a/docs/examples/authentication-flow.md
+++ b/docs/examples/authentication-flow.md
@@ -270,7 +270,7 @@ const providers = ['google', 'github', 'facebook'];
 
 providers.forEach(provider => {
   login
-    .on(`LOGIN_${provider.toUpperCase()}`, socialAuth)
+    .on(`LOGIN_${provider.toUpperCase()}`, 'socialAuth')
     .do((ctx) => {
       ctx.provider = provider;
       // Redirect to OAuth provider
@@ -312,8 +312,8 @@ socialCallback
       }
     }
   })
-  .on('SUCCESS', authenticated)
-  .on('ERROR', login);
+  .on('SUCCESS', 'authenticated')
+  .on('ERROR', 'login');
 ```
 
 ## Session Management

--- a/docs/examples/history-rollback.md
+++ b/docs/examples/history-rollback.md
@@ -17,13 +17,13 @@ const complete = machine.state('complete');
 const cancelled = machine.state('cancelled');
 
 // Define transitions
-idle.on('start', processing);
-processing.on('pay', payment);
-processing.on('cancel', cancelled);
-payment.on('success', complete);
-payment.on('fail', processing);
-complete.on('reset', idle);
-cancelled.on('reset', idle);
+idle.on('start', 'processing');
+processing.on('pay', 'payment');
+processing.on('cancel', 'cancelled');
+payment.on('success', 'complete');
+payment.on('fail', 'processing');
+complete.on('reset', 'idle');
+cancelled.on('reset', 'idle');
 
 machine.initial(idle);
 

--- a/docs/examples/react-integration.md
+++ b/docs/examples/react-integration.md
@@ -40,14 +40,14 @@ const machine = createMachine('counter');
 const idle = machine.state('idle');
 const counting = machine.state('counting');
 
-idle.on('START', counting);
+idle.on('START', 'counting');
 
 counting
-  .on('INCREMENT', counting)
+  .on('INCREMENT', 'counting')
   .do((ctx) => { ctx.count++; })
-  .on('DECREMENT', counting)
+  .on('DECREMENT', 'counting')
   .do((ctx) => { ctx.count--; })
-  .on('RESET', idle)
+  .on('RESET', 'idle')
   .do((ctx) => { ctx.count = 0; });
 
 machine.initial('idle');

--- a/docs/examples/svelte-integration.md
+++ b/docs/examples/svelte-integration.md
@@ -44,13 +44,13 @@ export function createStateMachineStore(machine, initialContext = {}) {
   const saving = machine.state('saving');
 
   editing
-    .on('SAVE', saving)
+    .on('SAVE', 'saving')
     .do((ctx, event) => {
       ctx.text = event.text;
     });
 
   saving
-    .on('SUCCESS', editing)
+    .on('SUCCESS', 'editing')
     .do(async (ctx) => {
       await fetch('/api/save', {
         method: 'POST',
@@ -58,7 +58,7 @@ export function createStateMachineStore(machine, initialContext = {}) {
       });
       ctx.saved = true;
     })
-    .on('ERROR', editing);
+    .on('ERROR', 'editing');
 
   machine.initial('editing');
 

--- a/docs/examples/traffic-light.md
+++ b/docs/examples/traffic-light.md
@@ -224,7 +224,7 @@ const emergency = machine.state('emergency');
 
 // Global emergency handler from any state
 machine
-  .on('EMERGENCY', emergency)
+  .on('EMERGENCY', 'emergency')
   .do((ctx) => {
     ctx.previousState = ctx.instance.current;
     ctx.emergencyActive = true;

--- a/docs/examples/typescript-usage.md
+++ b/docs/examples/typescript-usage.md
@@ -42,25 +42,25 @@ const error = machine.state('error');
 
 // Type-safe transitions
 idle
-  .on('START', loading)
+  .on('START', 'loading')
   .do((ctx: Context) => {
     ctx.count = 0;
   });
 
 loading
-  .on('LOGIN', active)
+  .on('LOGIN', 'active')
   .do(async (ctx: Context, event: Extract<Events, { type: 'LOGIN' }>) => {
     const response = await api.login(event.email, event.password);
     ctx.user = response.user;
     return { userId: response.user.id };
   })
-  .on('ERROR', error)
+  .on('ERROR', 'error')
   .do((ctx: Context, event: Extract<Events, { type: 'ERROR' }>) => {
     console.error(event.message);
   });
 
 active
-  .on('INCREMENT', active)
+  .on('INCREMENT', 'active')
   .do((ctx: Context) => {
     ctx.count++;
   });

--- a/docs/examples/visualization-examples.md
+++ b/docs/examples/visualization-examples.md
@@ -16,8 +16,8 @@ const machine = createMachine('toggle-switch')
 const off = machine.state('off')
 const on = machine.state('on')
 
-off.on('TOGGLE', on)
-on.on('TOGGLE', off)
+off.on('TOGGLE', 'on')
+on.on('TOGGLE', 'off')
 machine.initial(off)
 
 // Generate and preview
@@ -48,18 +48,21 @@ const red = machine.state('red')
 const yellow = machine.state('yellow')
 const green = machine.state('green')
 
-red.on('TIMER', green)
-green.on('TIMER', yellow)
-yellow.on('TIMER', red)
+red.on('TIMER', 'green')
+green.on('TIMER', 'yellow')
+yellow.on('TIMER', 'red')
 
 machine.initial(red)
 
 // Preview with current state tracking
 const instance = machine.start()
-await instance.visualizer().preview() // Shows red as current
+const diagram = instance.visualizer().visualize()
+console.log(diagram) // Shows red as current
 
 await instance.send('TIMER')
-await instance.visualizer().save('traffic-green.html') // Shows green
+// Save diagram to file using Node.js fs module
+const diagram = instance.visualizer().visualize()
+fs.writeFileSync('traffic-green.html', diagram) // Shows green
 ```
 
 ## Hierarchical Examples
@@ -91,16 +94,17 @@ playing.initial(normal)
 paused.initial(shortPause)
 
 // Transitions
-stopped.on('PLAY', normal)
-normal.on('FF', fastForward).on('REWIND', rewind).on('PAUSE', shortPause)
-fastForward.on('NORMAL', normal).on('PAUSE', shortPause)
-rewind.on('NORMAL', normal).on('PAUSE', shortPause)
-shortPause.on('RESUME', normal).on('LONG_PAUSE', longPause)
-longPause.on('RESUME', normal)
-playing.on('STOP', stopped)
-paused.on('STOP', stopped)
+stopped.on('PLAY', 'normal')
+normal.on('FF', 'fast-forward').on('REWIND', 'rewind').on('PAUSE', 'short-pause')
+fastForward.on('NORMAL', 'normal').on('PAUSE', 'short-pause')
+rewind.on('NORMAL', 'normal').on('PAUSE', 'short-pause')
+shortPause.on('RESUME', 'normal').on('LONG_PAUSE', 'long-pause')
+longPause.on('RESUME', 'normal')
+playing.on('STOP', 'stopped')
+paused.on('STOP', 'stopped')
 
-await machine.visualizer().preview()
+const diagram = machine.visualizer().visualize()
+console.log(diagram)
 ```
 
 **Key Features Shown:**
@@ -148,30 +152,32 @@ settings.initial(account)
 profile.initial(viewing)
 
 // Cross-level transitions
-login.on('LOGIN_SUCCESS', dashboard)
-register.on('REGISTER_SUCCESS', dashboard)
-forgotPassword.on('RESET_SUCCESS', login)
+login.on('LOGIN_SUCCESS', 'dashboard')
+register.on('REGISTER_SUCCESS', 'dashboard')
+forgotPassword.on('RESET_SUCCESS', 'login')
 
 // Within-level transitions
-login.on('REGISTER', register).on('FORGOT_PASSWORD', forgotPassword)
-register.on('BACK_TO_LOGIN', login)
-forgotPassword.on('BACK_TO_LOGIN', login)
+login.on('REGISTER', 'register').on('FORGOT_PASSWORD', 'forgot-password')
+register.on('BACK_TO_LOGIN', 'login')
+forgotPassword.on('BACK_TO_LOGIN', 'login')
 
-dashboard.on('VIEW_PROFILE', viewing).on('SETTINGS', account)
-viewing.on('EDIT', editing).on('DASHBOARD', dashboard)
-editing.on('SAVE', viewing).on('CANCEL', viewing)
+dashboard.on('VIEW_PROFILE', 'viewing').on('SETTINGS', 'account')
+viewing.on('EDIT', 'editing').on('DASHBOARD', 'dashboard')
+editing.on('SAVE', 'viewing').on('CANCEL', 'viewing')
 
-account.on('PRIVACY', privacy).on('SECURITY', security)
-privacy.on('ACCOUNT', account)
-security.on('ACCOUNT', account)
+account.on('PRIVACY', 'privacy').on('SECURITY', 'security')
+privacy.on('ACCOUNT', 'account')
+security.on('ACCOUNT', 'account')
 
 // Global transitions
-authenticated.on('LOGOUT', login)
-machine.on('SUSPEND_ACCOUNT', suspended)
-suspended.on('REACTIVATE', login)
+authenticated.on('LOGOUT', 'login')
+machine.on('SUSPEND_ACCOUNT', 'suspended')
+suspended.on('REACTIVATE', 'login')
 
 // Generate documentation
-await machine.visualizer().save('auth-flow-documentation.html')
+// Save diagram to file using Node.js fs module
+const diagram = machine.visualizer().visualize()
+fs.writeFileSync('auth-flow-documentation.html', diagram)
 ```
 
 ## Real-World Application Examples
@@ -214,28 +220,28 @@ payment.initial(processing)
 error.initial(networkError)
 
 // Main flow
-cart.on('CHECKOUT', shipping)
-shipping.on('CONTINUE', billing)
-billing.on('CONTINUE', review)
-review.on('SUBMIT_ORDER', processing)
-processing.on('APPROVED', approved)
-approved.on('CONFIRM', confirmation)
-confirmation.on('COMPLETE', completed)
+cart.on('CHECKOUT', 'shipping')
+shipping.on('CONTINUE', 'billing')
+billing.on('CONTINUE', 'review')
+review.on('SUBMIT_ORDER', 'processing')
+processing.on('APPROVED', 'approved')
+approved.on('CONFIRM', 'confirmation')
+confirmation.on('COMPLETE', 'completed')
 
 // Error flows
-processing.on('DECLINED', declined)
-declined.on('RETRY', retry)
-retry.on('SUBMIT', processing)
+processing.on('DECLINED', 'declined')
+declined.on('RETRY', 'retry')
+retry.on('SUBMIT', 'processing')
 
 // Global error handling
-machine.on('NETWORK_ERROR', networkError)
-machine.on('VALIDATION_ERROR', validationError)
-machine.on('PAYMENT_ERROR', paymentError)
+machine.on('NETWORK_ERROR', 'network-error')
+machine.on('VALIDATION_ERROR', 'validation-error')
+machine.on('PAYMENT_ERROR', 'payment-error')
 
 // Recovery flows
 networkError.on('RETRY', ctx => ctx.previousState || 'cart')
 validationError.on('FIX', ctx => ctx.previousState || 'cart')
-paymentError.on('RETRY', processing)
+paymentError.on('RETRY', 'processing')
 
 // Track user journey
 const instance = machine.start()
@@ -248,7 +254,9 @@ instance.subscribe(async ({ to }) => {
 // Start checkout process
 await instance.send('CHECKOUT')
 await instance.send('CONTINUE') // shipping -> billing
-await instance.visualizer().save('current-checkout-state.html')
+// Save diagram to file using Node.js fs module
+const diagram = instance.visualizer().visualize()
+fs.writeFileSync('current-checkout-state.html', diagram)
 ```
 
 ### Task Management System
@@ -288,30 +296,32 @@ review.initial(codeReview)
 blocked.initial(waitingDependency)
 
 // Workflow transitions
-backlog.on('START_WORK', assigned)
-assigned.on('BEGIN', active)
-active.on('SUBMIT_REVIEW', codeReview)
-  .on('BLOCK', waitingDependency)
+backlog.on('START_WORK', 'assigned')
+assigned.on('BEGIN', 'active')
+active.on('SUBMIT_REVIEW', 'code-review')
+  .on('BLOCK', 'waiting-dependency')
 
-codeReview.on('APPROVE', qaReview)
-  .on('REQUEST_CHANGES', active)
-qaReview.on('APPROVE', approved)
-  .on('REQUEST_CHANGES', active)
-approved.on('DEPLOY', done)
-rejected.on('REWORK', active)
+codeReview.on('APPROVE', 'qa-review')
+  .on('REQUEST_CHANGES', 'active')
+qaReview.on('APPROVE', 'approved')
+  .on('REQUEST_CHANGES', 'active')
+approved.on('DEPLOY', 'done')
+rejected.on('REWORK', 'active')
 
 // Unblocking flows
-waitingDependency.on('DEPENDENCY_READY', active)
-waitingClarification.on('CLARIFIED', active)
-waitingResources.on('RESOURCES_AVAILABLE', active)
+waitingDependency.on('DEPENDENCY_READY', 'active')
+waitingClarification.on('CLARIFIED', 'active')
+waitingResources.on('RESOURCES_AVAILABLE', 'active')
 
 // Administrative transitions
-done.on('ARCHIVE', archived)
-machine.on('CANCEL', archived)
-archived.on('RESTORE', backlog)
+done.on('ARCHIVE', 'archived')
+machine.on('CANCEL', 'archived')
+archived.on('RESTORE', 'backlog')
 
 // Generate project documentation
-await machine.visualizer().save('task-workflow.html')
+// Save diagram to file using Node.js fs module
+const diagram = machine.visualizer().visualize()
+fs.writeFileSync('task-workflow.html', diagram)
 
 // Track specific task
 const taskInstance = machine.start({ taskId: 'TASK-123' })
@@ -319,7 +329,9 @@ await taskInstance.send('START_WORK')
 await taskInstance.send('BEGIN')
 
 // Save current state for project dashboard
-await taskInstance.visualizer().save('task-123-status.html')
+// Save diagram to file using Node.js fs module
+const diagram = taskInstance.visualizer().visualize()
+fs.writeFileSync('task-123-status.html', diagram)
 ```
 
 ## Development Workflow Examples
@@ -367,38 +379,40 @@ deploy.initial(staging)
 failed.initial(buildFailed)
 
 // Success flow
-triggered.on('START_BUILD', installing)
-installing.on('SUCCESS', compiling)
-compiling.on('SUCCESS', packaging)
-packaging.on('SUCCESS', unitTests)
-unitTests.on('SUCCESS', integrationTests)
-integrationTests.on('SUCCESS', e2eTests)
-e2eTests.on('SUCCESS', staging)
-staging.on('SUCCESS', production)
-production.on('SUCCESS', monitoring)
-monitoring.on('STABLE', completed)
+triggered.on('START_BUILD', 'installing-dependencies')
+installing.on('SUCCESS', 'compiling')
+compiling.on('SUCCESS', 'packaging')
+packaging.on('SUCCESS', 'unit-tests')
+unitTests.on('SUCCESS', 'integration-tests')
+integrationTests.on('SUCCESS', 'e2e-tests')
+e2eTests.on('SUCCESS', 'staging')
+staging.on('SUCCESS', 'production')
+production.on('SUCCESS', 'monitoring')
+monitoring.on('STABLE', 'completed')
 
 // Failure flows
-installing.on('FAILURE', buildFailed)
-compiling.on('FAILURE', buildFailed)
-packaging.on('FAILURE', buildFailed)
-unitTests.on('FAILURE', testFailed)
-integrationTests.on('FAILURE', testFailed)
-e2eTests.on('FAILURE', testFailed)
-staging.on('FAILURE', deployFailed)
-production.on('FAILURE', deployFailed)
+installing.on('FAILURE', 'build-failed')
+compiling.on('FAILURE', 'build-failed')
+packaging.on('FAILURE', 'build-failed')
+unitTests.on('FAILURE', 'test-failed')
+integrationTests.on('FAILURE', 'test-failed')
+e2eTests.on('FAILURE', 'test-failed')
+staging.on('FAILURE', 'deploy-failed')
+production.on('FAILURE', 'deploy-failed')
 
 // Recovery flows
-buildFailed.on('RETRY', installing)
-testFailed.on('RETRY', unitTests)
-deployFailed.on('RETRY', staging)
+buildFailed.on('RETRY', 'installing-dependencies')
+testFailed.on('RETRY', 'unit-tests')
+deployFailed.on('RETRY', 'staging')
 
 // Manual interventions
-machine.on('ABORT', failed)
-failed.on('RESET', triggered)
+machine.on('ABORT', 'failed')
+failed.on('RESET', 'triggered')
 
 // Generate CI/CD documentation
-await machine.visualizer().save('cicd-pipeline.html')
+// Save diagram to file using Node.js fs module
+const diagram = machine.visualizer().visualize()
+fs.writeFileSync('cicd-pipeline.html', diagram)
 ```
 
 ## Debugging and Monitoring Examples
@@ -418,10 +432,10 @@ const tutorial = machine.state('tutorial')
 const completed = machine.state('completed')
 
 // Setup transitions...
-welcome.on('START', profile)
-profile.on('CONTINUE', preferences)
-preferences.on('CONTINUE', tutorial)
-tutorial.on('FINISH', completed)
+welcome.on('START', 'profile-setup')
+profile.on('CONTINUE', 'preferences')
+preferences.on('CONTINUE', 'tutorial')
+tutorial.on('FINISH', 'completed')
 
 machine.initial(welcome)
 
@@ -445,7 +459,9 @@ try {
   await instance.send('FINISH')
 } catch (error) {
   console.error('Onboarding failed:', error)
-  await instance.visualizer().save('onboarding-error-state.html')
+  // Save diagram to file using Node.js fs module
+const diagram = instance.visualizer().visualize()
+fs.writeFileSync('onboarding-error-state.html', diagram)
 }
 ```
 
@@ -461,9 +477,9 @@ const checkoutA = machineA.state('checkout')
 const paymentA = machineA.state('payment')
 const completeA = machineA.state('complete')
 
-cartA.on('CHECKOUT', checkoutA)
-checkoutA.on('PAY', paymentA)
-paymentA.on('SUCCESS', completeA)
+cartA.on('CHECKOUT', 'checkout')
+checkoutA.on('PAY', 'payment')
+paymentA.on('SUCCESS', 'complete')
 machineA.initial(cartA)
 
 // Version B - Enhanced flow
@@ -475,16 +491,20 @@ const paymentB = machineB.state('payment')
 const confirmationB = machineB.state('confirmation')
 const completeB = machineB.state('complete')
 
-cartB.on('REVIEW', reviewB)
-reviewB.on('CHECKOUT', checkoutB)
-checkoutB.on('PAY', paymentB)
-paymentB.on('SUCCESS', confirmationB)
-confirmationB.on('CONFIRM', completeB)
+cartB.on('REVIEW', 'review')
+reviewB.on('CHECKOUT', 'checkout')
+checkoutB.on('PAY', 'payment')
+paymentB.on('SUCCESS', 'confirmation')
+confirmationB.on('CONFIRM', 'complete')
 machineB.initial(cartB)
 
 // Generate comparison documentation
-await machineA.visualizer().save('checkout-flow-a.html')
-await machineB.visualizer().save('checkout-flow-b.html')
+// Save diagram to file using Node.js fs module
+const diagram = machineA.visualizer().visualize()
+fs.writeFileSync('checkout-flow-a.html', diagram)
+// Save diagram to file using Node.js fs module
+const diagram = machineB.visualizer().visualize()
+fs.writeFileSync('checkout-flow-b.html', diagram)
 
 // Track conversion rates
 const instanceA = machineA.start({ variant: 'A' })
@@ -509,17 +529,19 @@ const success = machine.state('success')
 const error = machine.state('error')
 const retrying = machine.state('retrying')
 
-idle.on('REQUEST', pending)
-pending.on('SUCCESS', success).on('ERROR', error)
-error.on('RETRY', retrying)
-retrying.on('REQUEST', pending).on('GIVE_UP', error)
-success.on('RESET', idle)
-error.on('RESET', idle)
+idle.on('REQUEST', 'pending')
+pending.on('SUCCESS', 'success').on('ERROR', 'error')
+error.on('RETRY', 'retrying')
+retrying.on('REQUEST', 'pending').on('GIVE_UP', 'error')
+success.on('RESET', 'idle')
+error.on('RESET', 'idle')
 
 machine.initial(idle)
 
 // Save as Mermaid for documentation
-await machine.visualizer().save('api-request-lifecycle.mmd')
+// Save diagram to file using Node.js fs module
+const diagram = machine.visualizer().visualize()
+fs.writeFileSync('api-request-lifecycle.mmd', diagram)
 
 // Create documentation template
 const documentation = `
@@ -565,7 +587,9 @@ const machine = createMachine('development-workflow')
 // ... (detailed state machine definition)
 
 // Generate onboarding materials
-await machine.visualizer().save('development-workflow-guide.html')
+// Save diagram to file using Node.js fs module
+const diagram = machine.visualizer().visualize()
+fs.writeFileSync('development-workflow-guide.html', diagram)
 
 // Create interactive tutorials
 const tutorialInstance = machine.start({ developer: 'new-hire' })
@@ -585,7 +609,8 @@ const diagram = visualizer.visualize()
 console.timeEnd('visualization-generation')
 
 console.time('preview-generation')
-await largeMachine.visualizer().preview()
+const diagram = largeMachine.visualizer().visualize()
+console.log(diagram)
 console.timeEnd('preview-generation')
 ```
 

--- a/docs/examples/vue-integration.md
+++ b/docs/examples/vue-integration.md
@@ -73,22 +73,22 @@ const loading = machine.state('loading');
 const success = machine.state('success');
 const error = machine.state('error');
 
-idle.on('FETCH', loading);
+idle.on('FETCH', 'loading');
 
 loading
   .enter(() => console.log('Fetching data...'))
-  .on('SUCCESS', success)
+  .on('SUCCESS', 'success')
   .do(async (ctx) => {
     const res = await fetch('/api/data');
     ctx.data = await res.json();
   })
-  .on('ERROR', error)
+  .on('ERROR', 'error')
   .do((ctx, event) => {
     ctx.error = event.message;
   });
 
-success.on('RESET', idle);
-error.on('RETRY', loading);
+success.on('RESET', 'idle');
+error.on('RETRY', 'loading');
 
 machine.initial('idle');
 

--- a/docs/visualization.md
+++ b/docs/visualization.md
@@ -46,21 +46,19 @@ graph TD
   classDef initial fill:#f3e5f5,stroke:#4a148c,stroke-width:2px
 ```
 
-### Browser Preview
-
-```javascript
-// Open diagram in browser for immediate visualization
-await machine.visualizer().preview()
-```
 
 ### Save to File
 
 ```javascript
 // Save as HTML file (auto-detected from extension)
-await machine.visualizer().save('my-state-machine.html')
+// Save diagram to file using Node.js fs module
+const diagram = machine.visualizer().visualize()
+fs.writeFileSync('my-state-machine.html', diagram)
 
 // Save as Mermaid text file
-await machine.visualizer().save('my-state-machine.mmd')
+// Save diagram to file using Node.js fs module
+const diagram = machine.visualizer().visualize()
+fs.writeFileSync('my-state-machine.mmd', diagram)
 ```
 
 ## API Reference
@@ -95,10 +93,12 @@ Returns a visualizer object with preview and save methods.
 const viz = machine.visualizer()
 
 // Preview in browser
-await viz.preview()
+// Use the diagram text with external tools
+console.log(viz.visualize())
 
 // Save to file
-await viz.save('diagram.html')
+// Save diagram to file
+fs.writeFileSync('diagram.html', viz.visualize())
 ```
 
 ### Instance Methods
@@ -241,7 +241,9 @@ const diagram = visualizer.visualize()
 When saving with `.html` extension, generates a complete HTML page with embedded Mermaid:
 
 ```javascript
-await machine.visualizer().save('state-machine.html')
+// Save diagram to file using Node.js fs module
+const diagram = machine.visualizer().visualize()
+fs.writeFileSync('state-machine.html', diagram)
 ```
 
 **Generated HTML includes:**
@@ -255,7 +257,9 @@ await machine.visualizer().save('state-machine.html')
 When saving with `.mmd` or `.md` extension, saves raw Mermaid syntax:
 
 ```javascript
-await machine.visualizer().save('state-machine.mmd')
+// Save diagram to file using Node.js fs module
+const diagram = machine.visualizer().visualize()
+fs.writeFileSync('state-machine.mmd', diagram)
 ```
 
 **Generated file contains:**

--- a/src/core/state.js
+++ b/src/core/state.js
@@ -63,6 +63,9 @@ export const createState = (id, parent = null) => {
     },
 
     on(event, target) {
+      if (typeof target !== 'string' && typeof target !== 'function') {
+        throw new Error(`State transition target must be a string or function, got ${typeof target}`)
+      }
       const transition = createTransition(event, target, state)
       if (!transitions.has(event)) {
         transitions.set(event, [])

--- a/src/core/transition.js
+++ b/src/core/transition.js
@@ -4,7 +4,7 @@
 
 /**
  * @param {string} event
- * @param {string|Object|Function} target
+ * @param {string|Function} target
  * @param {Object|null} source
  * @returns {import('../../types/index.js').Transition}
  */
@@ -76,7 +76,7 @@ export const createTransition = (event, target, source) => {
         if (typeof result === 'string') {
           return stateResolver(result)
         }
-        return result
+        throw new Error(`Dynamic target function must return a string, got ${typeof result}`)
       }
 
       if (typeof target === 'string') {
@@ -86,7 +86,7 @@ export const createTransition = (event, target, source) => {
         return stateResolver(target)
       }
 
-      return target
+      throw new Error(`Transition target must be a string or function, got ${typeof target}`)
     }
   }
 

--- a/tests/api-exports.test.js
+++ b/tests/api-exports.test.js
@@ -64,8 +64,8 @@ describe('API Exports', () => {
         ctx.finished = true;
       };
 
-      idle.on('START', active).do(startAction);
-      active.on('FINISH', complete).do(finishAction);
+      idle.on('START', 'active').do(startAction);
+      active.on('FINISH', 'complete').do(finishAction);
 
       machine.initial(idle);
 
@@ -107,8 +107,8 @@ describe('API Exports', () => {
         ctx.counter = (ctx.counter || 0) + 1;
       };
 
-      s1.on('TOGGLE', s2).do(testAction);
-      s2.on('TOGGLE', s1).do(testAction);
+      s1.on('TOGGLE', 's2').do(testAction);
+      s2.on('TOGGLE', 's1').do(testAction);
       machine.initial(s1);
 
       const instance = machine.start();

--- a/tests/async-actions.test.js
+++ b/tests/async-actions.test.js
@@ -19,13 +19,13 @@ describe('Async Actions', () => {
       loading = machine.state('loading')
       loaded = machine.state('loaded')
 
-      idle.on('LOAD', loading).do(async ctx => {
+      idle.on('LOAD', 'loading').do(async ctx => {
         // Simulate API call
         await new Promise(resolve => setTimeout(resolve, 10))
         ctx.data = { id: 1, name: 'Test' }
       })
 
-      loading.on('DONE', loaded)
+      loading.on('DONE', 'loaded')
 
       machine.initial(idle)
       instance = machine.start({})
@@ -63,7 +63,7 @@ describe('Async Actions', () => {
       fetching = machine.state('fetching')
       done = machine.state('done')
 
-      idle.on('FETCH', fetching).do(async (ctx, event) => {
+      idle.on('FETCH', 'fetching').do(async (ctx, event) => {
         const response = await Promise.resolve({
           data: { userId: event.userId, items: [1, 2, 3] }
         })
@@ -71,7 +71,7 @@ describe('Async Actions', () => {
         return { itemCount: response.data.items.length }
       })
 
-      fetching.on('COMPLETE', done)
+      fetching.on('COMPLETE', 'done')
 
       machine.initial(idle)
       instance = machine.start({})
@@ -107,7 +107,7 @@ describe('Async Actions', () => {
       actionOrder = []
 
       idle
-        .on('PROCESS', processing)
+        .on('PROCESS', 'processing')
         .do(ctx => {
           actionOrder.push('sync1')
           ctx.step1 = true
@@ -127,7 +127,7 @@ describe('Async Actions', () => {
           ctx.step4 = true
         })
 
-      processing.on('DONE', complete)
+      processing.on('DONE', 'complete')
 
       machine.initial(idle)
       instance = machine.start({})
@@ -160,12 +160,12 @@ describe('Async Actions', () => {
       processing = machine.state('processing')
       error = machine.state('error')
 
-      idle.on('FAIL', processing).do(async () => {
+      idle.on('FAIL', 'processing').do(async () => {
         throw new Error('Async action failed')
       })
 
       idle
-        .on('PARTIAL', processing)
+        .on('PARTIAL', 'processing')
         .do(ctx => {
           ctx.step1 = true
         })
@@ -217,7 +217,7 @@ describe('Async Actions', () => {
       busy = machine.state('busy')
 
       idle
-        .on('SEQUENTIAL', busy)
+        .on('SEQUENTIAL', 'busy')
         .do(async ctx => {
           await new Promise(resolve => setTimeout(resolve, 20))
           ctx.first = Date.now()
@@ -261,7 +261,7 @@ describe('Async Actions', () => {
         return { fetched: 'posts' }
       }
 
-      idle.on('LOAD', busy).do(fetchUser).do(fetchPosts)
+      idle.on('LOAD', 'busy').do(fetchUser).do(fetchPosts)
 
       machine.initial(idle)
       instance = machine.start({})

--- a/tests/context-management.test.js
+++ b/tests/context-management.test.js
@@ -51,11 +51,11 @@ describe('Context Management', () => {
       idle = machine.state('idle')
       active = machine.state('active')
 
-      idle.on('INCREMENT', active).do(ctx => {
+      idle.on('INCREMENT', 'active').do(ctx => {
         ctx.count = (ctx.count || 0) + 1
       })
 
-      active.on('RESET', idle)
+      active.on('RESET', 'idle')
 
       machine.initial(idle)
     })
@@ -65,13 +65,13 @@ describe('Context Management', () => {
       const machine1 = createMachine('separate1')
       const idle1 = machine1.state('idle')
       const counting1 = machine1.state('counting')
-      idle1.on('INCREMENT', counting1).do((ctx) => { ctx.count = (ctx.count || 0) + 1 })
+      idle1.on('INCREMENT', 'counting').do((ctx) => { ctx.count = (ctx.count || 0) + 1 })
       machine1.initial(idle1)
 
       const machine2 = createMachine('separate2')
       const idle2 = machine2.state('idle')
       const counting2 = machine2.state('counting')
-      idle2.on('INCREMENT', counting2).do((ctx) => { ctx.count = (ctx.count || 0) + 1 })
+      idle2.on('INCREMENT', 'counting').do((ctx) => { ctx.count = (ctx.count || 0) + 1 })
       machine2.initial(idle2)
 
       const instance1 = machine1.start()
@@ -98,7 +98,7 @@ describe('Context Management', () => {
       idle = machine.state('idle')
       processing = machine.state('processing')
 
-      idle.on('UPDATE', processing).do((ctx, event) => {
+      idle.on('UPDATE', 'processing').do((ctx, event) => {
         // Direct mutation
         ctx.value = event.value
         // Nested object update
@@ -143,11 +143,11 @@ describe('Context Management', () => {
       denied = machine.state('denied')
 
       idle
-        .on('ACCESS', allowed)
+        .on('ACCESS', 'allowed')
         .if(ctx => ctx.user && ctx.user.role === 'admin')
 
       idle
-        .on('ACCESS', denied)
+        .on('ACCESS', 'denied')
         .if(ctx => !ctx.user || ctx.user.role !== 'admin')
 
       machine.initial(idle)
@@ -199,8 +199,8 @@ describe('Context Management', () => {
         ctx.enteredFrom = event ? event.type : 'initial'
       })
 
-      state1.on('NEXT', state2)
-      state2.on('BACK', state1)
+      state1.on('NEXT', 'state2')
+      state2.on('BACK', 'state1')
 
       machine.initial(state1)
       instance = machine.start({})
@@ -239,13 +239,13 @@ describe('Context Management', () => {
       processing = machine.state('processing')
       complete = machine.state('complete')
 
-      idle.on('START', processing).do((ctx, event) => {
+      idle.on('START', 'processing').do((ctx, event) => {
         ctx.items = event.items || []
         ctx.results = []
       })
 
       processing
-        .on('PROCESS_ITEM', processing)
+        .on('PROCESS_ITEM', 'processing')
         .do((ctx, event) => {
           const item = ctx.items.shift()
           if (item) {
@@ -258,7 +258,7 @@ describe('Context Management', () => {
         })
         .if(ctx => ctx.items.length > 0)
 
-      processing.on('PROCESS_ITEM', complete).if(ctx => ctx.items.length === 0)
+      processing.on('PROCESS_ITEM', 'complete').if(ctx => ctx.items.length === 0)
 
       machine.initial(idle)
     })

--- a/tests/event-subscriptions.test.js
+++ b/tests/event-subscriptions.test.js
@@ -19,8 +19,8 @@ describe('Event Subscriptions', () => {
       active = machine.state('active')
       notifications = []
 
-      idle.on('ACTIVATE', active)
-      active.on('DEACTIVATE', idle)
+      idle.on('ACTIVATE', 'active')
+      active.on('DEACTIVATE', 'idle')
 
       machine.initial(idle)
       instance = machine.start()
@@ -77,7 +77,7 @@ describe('Event Subscriptions', () => {
       subscriber2Events = []
       subscriber3Events = []
 
-      idle.on('GO', active)
+      idle.on('GO', 'active')
       machine.initial(idle)
       instance = machine.start()
 
@@ -136,8 +136,8 @@ describe('Event Subscriptions', () => {
       active = machine.state('active')
       events = []
 
-      idle.on('GO', active)
-      active.on('BACK', idle)
+      idle.on('GO', 'active')
+      active.on('BACK', 'idle')
 
       machine.initial(idle)
       instance = machine.start()
@@ -200,8 +200,8 @@ describe('Event Subscriptions', () => {
       events = []
 
       parent.initial(child1)
-      child1.on('NEXT', child2)
-      child2.on('PREV', child1)
+      child1.on('NEXT', 'child2')
+      child2.on('PREV', 'child1')
 
       machine.initial(parent)
       instance = machine.start()
@@ -223,7 +223,7 @@ describe('Event Subscriptions', () => {
 
     it('should handle parent state transitions', async () => {
       const other = machine.state('other')
-      parent.on('LEAVE', other)
+      parent.on('LEAVE', 'other')
 
       await instance.send('LEAVE')
 
@@ -251,7 +251,7 @@ describe('Event Subscriptions', () => {
       goodEvents = []
       errorEvents = []
 
-      idle.on('GO', active)
+      idle.on('GO', 'active')
       machine.initial(idle)
       instance = machine.start()
 
@@ -312,7 +312,7 @@ describe('Event Subscriptions', () => {
       active = machine.state('active')
       events = []
 
-      active.on('REFRESH', active)
+      active.on('REFRESH', 'active')
       machine.initial(active)
       instance = machine.start()
 
@@ -351,7 +351,7 @@ describe('Event Subscriptions', () => {
       actionOrder = []
 
       idle
-        .on('LOAD', loading)
+        .on('LOAD', 'loading')
         .do(() => {
           actionOrder.push('sync-action')
         })
@@ -360,7 +360,7 @@ describe('Event Subscriptions', () => {
           await new Promise(resolve => setTimeout(resolve, 10))
         })
 
-      loading.on('DONE', loaded)
+      loading.on('DONE', 'loaded')
 
       machine.initial(idle)
       instance = machine.start()

--- a/tests/fire-and-forget-actions.test.js
+++ b/tests/fire-and-forget-actions.test.js
@@ -19,7 +19,7 @@ describe('Fire-and-Forget Actions', () => {
       active = machine.state('active')
       fireLog = []
 
-      idle.on('START', active).fire(() => {
+      idle.on('START', 'active').fire(() => {
         fireLog.push('fired')
       })
 
@@ -37,7 +37,7 @@ describe('Fire-and-Forget Actions', () => {
     it('should not block transition', async () => {
       const startTime = Date.now()
 
-      idle.on('SLOW', active).fire(async () => {
+      idle.on('SLOW', 'active').fire(async () => {
         await new Promise(resolve => setTimeout(resolve, 100))
         fireLog.push('slow-fired')
       })
@@ -65,7 +65,7 @@ describe('Fire-and-Forget Actions', () => {
       executionLog = []
 
       idle
-        .on('GO', active)
+        .on('GO', 'active')
         .do(() => {
           executionLog.push('sync1')
         })
@@ -134,11 +134,11 @@ describe('Fire-and-Forget Actions', () => {
         errorLog.push(msg)
       }
 
-      idle.on('ERROR', active).fire(() => {
+      idle.on('ERROR', 'active').fire(() => {
         throw new Error('Fire action error')
       })
 
-      idle.on('ASYNC_ERROR', active).fire(async () => {
+      idle.on('ASYNC_ERROR', 'active').fire(async () => {
         await new Promise(resolve => setTimeout(resolve, 10))
         throw new Error('Async fire action error')
       })
@@ -193,7 +193,7 @@ describe('Fire-and-Forget Actions', () => {
       contextLog = []
 
       idle
-        .on('UPDATE', active)
+        .on('UPDATE', 'active')
         .do(ctx => {
           ctx.count = 1
         })
@@ -263,7 +263,7 @@ describe('Fire-and-Forget Actions', () => {
       }
 
       idle
-        .on('PURCHASE', active)
+        .on('PURCHASE', 'active')
         .do((ctx, event) => {
           ctx.lastPurchase = event.itemId
         })
@@ -309,7 +309,7 @@ describe('Fire-and-Forget Actions', () => {
       fireOrder = []
 
       idle
-        .on('MULTI', active)
+        .on('MULTI', 'active')
         .fire(() => {
           fireOrder.push(1)
         })

--- a/tests/hierarchical-states.test.js
+++ b/tests/hierarchical-states.test.js
@@ -25,10 +25,10 @@ describe('Hierarchical States', () => {
 
       unauth.initial(login)
 
-      login.on('REGISTER', register)
-      register.on('BACK', login)
-      unauth.on('LOGIN_SUCCESS', auth)
-      auth.on('LOGOUT', unauth)
+      login.on('REGISTER', 'register')
+      register.on('BACK', 'login')
+      unauth.on('LOGIN_SUCCESS', 'authenticated')
+      auth.on('LOGOUT', 'unauthenticated')
 
       machine.initial(unauth)
       instance = machine.start()
@@ -80,10 +80,10 @@ describe('Hierarchical States', () => {
       settings.initial(profile)
       profile.initial(basic)
 
-      dashboard.on('SETTINGS', settings)
-      settings.on('BACK', dashboard)
-      basic.on('ADVANCED', advanced)
-      advanced.on('BASIC', basic)
+      dashboard.on('SETTINGS', 'settings')
+      settings.on('BACK', 'dashboard')
+      basic.on('ADVANCED', 'advanced')
+      advanced.on('BASIC', 'basic')
 
       machine.initial(app)
       instance = machine.start()
@@ -127,12 +127,12 @@ describe('Hierarchical States', () => {
       offline.initial(disconnected)
 
       // Parent-level transitions
-      machine.on('NETWORK_DOWN', offline)
-      machine.on('NETWORK_UP', online)
+      machine.on('NETWORK_DOWN', 'offline')
+      machine.on('NETWORK_UP', 'online')
 
       // Child transitions
-      connected.on('CONNECTION_LOST', reconnecting)
-      reconnecting.on('RECONNECTED', connected)
+      connected.on('CONNECTION_LOST', 'reconnecting')
+      reconnecting.on('RECONNECTED', 'connected')
 
       machine.initial(online)
       instance = machine.start()
@@ -233,8 +233,8 @@ describe('Hierarchical States', () => {
         .exit(() => lifecycleLog.push('child2-exit'))
 
       parent.initial(child1)
-      child1.on('NEXT', child2)
-      child2.on('PREV', child1)
+      child1.on('NEXT', 'child2')
+      child2.on('PREV', 'child1')
 
       machine.initial(parent)
       instance = machine.start()
@@ -254,7 +254,7 @@ describe('Hierarchical States', () => {
 
     it('should exit child before parent', async () => {
       const other = machine.state('other')
-      parent.on('LEAVE', other)
+      parent.on('LEAVE', 'other')
 
       lifecycleLog = []
       await instance.send('LEAVE')
@@ -287,12 +287,12 @@ describe('Hierarchical States', () => {
       b.initial(b1)
 
       // Cross-hierarchy transitions
-      a1.on('CROSS', b2)
-      b2.on('BACK', a1)
+      a1.on('CROSS', 'b.2')
+      b2.on('BACK', 'a.1')
 
       // Parent transitions
-      a.on('SWITCH', b)
-      b.on('SWITCH', a)
+      a.on('SWITCH', 'b')
+      b.on('SWITCH', 'a')
 
       machine.initial(a)
       instance = machine.start()

--- a/tests/history-system.test.js
+++ b/tests/history-system.test.js
@@ -18,12 +18,12 @@ describe('History System', () => {
     const complete = machine.state('complete')
     const error = machine.state('error')
 
-    idle.on('start', processing)
-    processing.on('finish', complete)
-    processing.on('fail', error)
-    complete.on('reset', idle)
-    error.on('retry', processing)
-    error.on('reset', idle)
+    idle.on('start', 'processing')
+    processing.on('finish', 'complete')
+    processing.on('fail', 'error')
+    complete.on('reset', 'idle')
+    error.on('retry', 'processing')
+    error.on('reset', 'idle')
 
     machine.initial(idle)
 

--- a/tests/npm-consumers/browser-consumer/browser-test.js
+++ b/tests/npm-consumers/browser-consumer/browser-test.js
@@ -123,9 +123,9 @@
             log('  ✅ States created successfully', 'success');
 
             // Test 3: Transitions
-            idle.on('START', active);
-            active.on('COMPLETE', completed);
-            completed.on('RESET', idle);
+            idle.on('START', 'active');
+            active.on('COMPLETE', 'completed');
+            completed.on('RESET', 'idle');
             machine.initial(idle);
 
             log('  ✅ Transitions configured', 'success');
@@ -235,8 +235,8 @@
             const machine = machines[0];
             const state1 = machine.state('state1');
             const state2 = machine.state('state2');
-            state1.on('TOGGLE', state2);
-            state2.on('TOGGLE', state1);
+            state1.on('TOGGLE', 'state2');
+            state2.on('TOGGLE', 'state1');
             machine.initial(state1);
 
             const instance = machine.start();

--- a/tests/npm-consumers/cjs-consumer/require-test.js
+++ b/tests/npm-consumers/cjs-consumer/require-test.js
@@ -34,9 +34,9 @@ const processing = machine.state('processing');
 const completed = machine.state('completed');
 
 // Define transitions
-idle.on('START', processing);
-processing.on('COMPLETE', completed);
-completed.on('RESET', idle);
+idle.on('START', 'processing');
+processing.on('COMPLETE', 'completed');
+completed.on('RESET', 'idle');
 
 // Set initial state
 machine.initial(idle);

--- a/tests/npm-consumers/esm-consumer/import-test.js
+++ b/tests/npm-consumers/esm-consumer/import-test.js
@@ -20,9 +20,9 @@ const processing = machine.state('processing');
 const completed = machine.state('completed');
 
 // Define transitions
-idle.on('START', processing);
-processing.on('COMPLETE', completed);
-completed.on('RESET', idle);
+idle.on('START', 'processing');
+processing.on('COMPLETE', 'completed');
+completed.on('RESET', 'idle');
 
 // Set initial state
 machine.initial(idle);

--- a/tests/npm-consumers/typescript-consumer/types-test.js
+++ b/tests/npm-consumers/typescript-consumer/types-test.js
@@ -28,9 +28,9 @@ const processingState = machine.state('processing');
 const completedState = machine.state('completed');
 
 // TypeScript should enforce correct method signatures
-idleState.on('START', processingState);
-processingState.on('COMPLETE', completedState);
-completedState.on('RESET', idleState);
+idleState.on('START', 'processing');
+processingState.on('COMPLETE', 'completed');
+completedState.on('RESET', 'idle');
 
 machine.initial(idleState);
 

--- a/tests/performance-benchmarks.test.js
+++ b/tests/performance-benchmarks.test.js
@@ -36,7 +36,7 @@ describe('Performance Benchmarks', () => {
         const machine = srcModule.createMachine(`test-${i}`);
         const idle = machine.state('idle');
         const active = machine.state('active');
-        idle.on('START', active);
+        idle.on('START', 'active');
         machine.initial(idle);
       }
 
@@ -53,8 +53,8 @@ describe('Performance Benchmarks', () => {
       const idle = machine.state('idle');
       const active = machine.state('active');
 
-      idle.on('START', active);
-      active.on('STOP', idle);
+      idle.on('START', 'active');
+      active.on('STOP', 'idle');
       machine.initial(idle);
 
       const instance = machine.start();
@@ -85,8 +85,8 @@ describe('Performance Benchmarks', () => {
       const idle = machine.state('idle');
       const active = machine.state('active');
 
-      idle.on('START', active).do(perfAction);
-      active.on('TRIGGER', active).do(perfAction);
+      idle.on('START', 'active').do(perfAction);
+      active.on('TRIGGER', 'active').do(perfAction);
       machine.initial(idle);
 
       const instance = machine.start();
@@ -128,15 +128,15 @@ describe('Performance Benchmarks', () => {
       };
 
       // Set up transitions
-      stateObjects.idle.on('LOAD', stateObjects.loading).do(actions.load);
-      stateObjects.loading.on('PROCESS', stateObjects.processing).do(actions.process);
-      stateObjects.processing.on('VALIDATE', stateObjects.validating).do(actions.validate);
-      stateObjects.validating.on('COMPLETE', stateObjects.complete).do(actions.complete);
-      stateObjects.validating.on('ERROR', stateObjects.error).do(actions.error);
-      stateObjects.complete.on('RESET', stateObjects.idle);
-      stateObjects.error.on('RESET', stateObjects.idle);
+      stateObjects.idle.on('LOAD', 'loading').do(actions.load);
+      stateObjects.loading.on('PROCESS', 'processing').do(actions.process);
+      stateObjects.processing.on('VALIDATE', 'validating').do(actions.validate);
+      stateObjects.validating.on('COMPLETE', 'complete').do(actions.complete);
+      stateObjects.validating.on('ERROR', 'error').do(actions.error);
+      stateObjects.complete.on('RESET', 'idle');
+      stateObjects.error.on('RESET', 'idle');
 
-      machine.initial(stateObjects.idle);
+      machine.initial('idle');
 
       const instance = machine.start();
       const iterations = 200;
@@ -180,7 +180,7 @@ describe('Performance Benchmarks', () => {
         const machine = srcModule.createMachine(`memory-test-${i}`);
         const s1 = machine.state('s1');
         const s2 = machine.state('s2');
-        s1.on('GO', s2);
+        s1.on('GO', 's2');
         machine.initial(s1);
         machines.push(machine.start());
       }
@@ -251,7 +251,7 @@ describe('Performance Benchmarks', () => {
       const state1 = machine.state('state1');
       const state2 = machine.state('state2');
 
-      state1.on('GO', state2);
+      state1.on('GO', 'state2');
       machine.initial(state1);
 
       const instance = machine.start();

--- a/tests/simple-transitions.test.js
+++ b/tests/simple-transitions.test.js
@@ -18,32 +18,32 @@ describe('Simple Transitions', () => {
     })
 
     it('should create transition with event name', () => {
-      const transition = idle.on('START', active)
+      const transition = idle.on('START', 'active')
       expect(transition).toBeDefined()
     })
 
     it('should create transition with target state', () => {
-      const transition = idle.on('START', active)
-      expect(transition.target).toBe(active)
+      const transition = idle.on('START', 'active')
+      expect(transition.target).toBe('active')
     })
 
     it('should store transition in source state', () => {
-      idle.on('START', active)
+      idle.on('START', 'active')
       const transitions = idle.getTransitions('START')
       expect(transitions.length).toBe(1)
     })
 
     it('should allow multiple events to same target', () => {
-      idle.on('START', active)
-      idle.on('ACTIVATE', active)
+      idle.on('START', 'active')
+      idle.on('ACTIVATE', 'active')
       expect(idle.getTransitions('START').length).toBe(1)
       expect(idle.getTransitions('ACTIVATE').length).toBe(1)
     })
 
     it('should allow same event to different targets with guards', () => {
       const error = machine.state('error')
-      idle.on('START', active)
-      idle.on('START', error)
+      idle.on('START', 'active')
+      idle.on('START', 'error')
       const transitions = idle.getTransitions('START')
       expect(transitions.length).toBe(2)
     })
@@ -59,8 +59,8 @@ describe('Simple Transitions', () => {
       machine = createMachine('toggle')
       off = machine.state('off')
       on = machine.state('on')
-      off.on('TOGGLE', on)
-      on.on('TOGGLE', off)
+      off.on('TOGGLE', 'on')
+      on.on('TOGGLE', 'off')
       machine.initial(off)
       instance = machine.start()
     })
@@ -103,8 +103,8 @@ describe('Simple Transitions', () => {
       running = machine.state('running')
       stopped = machine.state('stopped')
 
-      idle.on('START', running)
-      running.on('STOP', stopped)
+      idle.on('START', 'running')
+      running.on('STOP', 'stopped')
 
       machine.initial(idle)
       instance = machine.start()
@@ -141,7 +141,7 @@ describe('Simple Transitions', () => {
     beforeEach(() => {
       machine = createMachine('refresh')
       active = machine.state('active')
-      active.on('REFRESH', active)
+      active.on('REFRESH', 'active')
       machine.initial(active)
       instance = machine.start()
     })

--- a/tests/state-lifecycle.test.js
+++ b/tests/state-lifecycle.test.js
@@ -30,8 +30,8 @@ describe('State Lifecycle', () => {
         ctx.entryEvent = event ? event.type : null
       })
 
-      idle.on('ACTIVATE', active)
-      active.on('DEACTIVATE', idle)
+      idle.on('ACTIVATE', 'active')
+      active.on('DEACTIVATE', 'idle')
 
       machine.initial(idle)
     })
@@ -82,8 +82,8 @@ describe('State Lifecycle', () => {
         ctx.exitEvent = event ? event.type : null
       })
 
-      idle.on('ACTIVATE', active)
-      active.on('DEACTIVATE', idle)
+      idle.on('ACTIVATE', 'active')
+      active.on('DEACTIVATE', 'idle')
 
       machine.initial(idle)
       instance = machine.start({})
@@ -134,9 +134,9 @@ describe('State Lifecycle', () => {
         .enter(() => lifecycleLog.push('C-enter'))
         .exit(() => lifecycleLog.push('C-exit'))
 
-      stateA.on('TO_B', stateB)
-      stateB.on('TO_C', stateC)
-      stateC.on('TO_A', stateA)
+      stateA.on('TO_B', 'stateB')
+      stateB.on('TO_C', 'stateC')
+      stateC.on('TO_A', 'stateA')
 
       machine.initial(stateA)
       instance = machine.start()
@@ -190,7 +190,7 @@ describe('State Lifecycle', () => {
         .enter(() => actionOrder.push('active-enter-1'))
         .enter(() => actionOrder.push('active-enter-2'))
 
-      idle.on('GO', active)
+      idle.on('GO', 'active')
 
       machine.initial(idle)
     })
@@ -235,7 +235,7 @@ describe('State Lifecycle', () => {
           ctx.exitCount = (ctx.exitCount || 0) + 1
         })
 
-      active.on('REFRESH', active)
+      active.on('REFRESH', 'active')
 
       machine.initial(active)
       instance = machine.start({})
@@ -285,7 +285,7 @@ describe('State Lifecycle', () => {
       idle.exit(cleanup)
       active.enter(logEntry)
 
-      idle.on('START', active)
+      idle.on('START', 'active')
 
       machine.initial(idle)
       instance = machine.start({})

--- a/tests/string-only-transitions.test.js
+++ b/tests/string-only-transitions.test.js
@@ -1,0 +1,171 @@
+/**
+ * String-only transition validation tests
+ * Tests that transitions only accept string targets, not objects
+ */
+
+import { createMachine } from '../src/index.js'
+
+describe('String-Only Transition Validation', () => {
+  let machine
+  let state1
+  let state2
+
+  beforeEach(() => {
+    machine = createMachine('test-machine')
+    state1 = machine.state('state1')
+    state2 = machine.state('state2')
+  })
+
+  describe('State.on() validation', () => {
+    it('should accept string targets', () => {
+      expect(() => {
+        state1.on('EVENT', 'state2')
+      }).not.toThrow()
+    })
+
+    it('should accept function targets that return strings', () => {
+      expect(() => {
+        state1.on('EVENT', (ctx) => ctx.condition ? 'state2' : 'state1')
+      }).not.toThrow()
+    })
+
+    it('should reject state object targets', () => {
+      expect(() => {
+        state1.on('EVENT', state2)
+      }).toThrow('State transition target must be a string or function')
+    })
+
+    it('should reject non-string, non-function targets', () => {
+      expect(() => {
+        state1.on('EVENT', 123)
+      }).toThrow('State transition target must be a string or function')
+
+      expect(() => {
+        state1.on('EVENT', true)
+      }).toThrow('State transition target must be a string or function')
+
+      expect(() => {
+        state1.on('EVENT', { id: 'state2' })
+      }).toThrow('State transition target must be a string or function')
+
+      expect(() => {
+        state1.on('EVENT', null)
+      }).toThrow('State transition target must be a string or function')
+    })
+  })
+
+  describe('Machine.on() validation', () => {
+    it('should accept string targets for global transitions', () => {
+      expect(() => {
+        machine.on('RESET', 'state1')
+      }).not.toThrow()
+    })
+
+    it('should reject state object targets for global transitions', () => {
+      expect(() => {
+        machine.on('RESET', state1)
+      }).toThrow('State transition target must be a string or function')
+    })
+  })
+
+  describe('Dynamic target validation', () => {
+    it('should accept functions that return strings', async () => {
+      state1.on('DYNAMIC', (ctx) => 'state2')
+      machine.initial(state1)
+
+      const instance = machine.start()
+      await instance.send('DYNAMIC')
+      expect(instance.current).toBe('state2')
+    })
+
+    it('should throw error if dynamic function returns non-string', async () => {
+      state1.on('DYNAMIC', (ctx) => state2)
+      machine.initial(state1)
+
+      const instance = machine.start()
+      await expect(instance.send('DYNAMIC')).rejects.toThrow(
+        'Dynamic target function must return a string'
+      )
+    })
+
+    it('should throw error if dynamic function returns null', async () => {
+      state1.on('DYNAMIC', (ctx) => null)
+      machine.initial(state1)
+
+      const instance = machine.start()
+      await expect(instance.send('DYNAMIC')).rejects.toThrow(
+        'Dynamic target function must return a string'
+      )
+    })
+  })
+
+  describe('Relative path targets', () => {
+    it('should accept parent reference strings', () => {
+      const parent = machine.state('parent')
+      const child = parent.state('child')
+
+      expect(() => {
+        child.on('UP', '^')
+      }).not.toThrow()
+    })
+
+    it('should accept sibling reference strings', () => {
+      const parent = machine.state('parent')
+      const child1 = parent.state('child1')
+      const child2 = parent.state('child2')
+
+      expect(() => {
+        child1.on('SIBLING', '^.child2')
+      }).not.toThrow()
+    })
+
+    it('should accept grandparent reference strings', () => {
+      const grandparent = machine.state('grandparent')
+      const parent = grandparent.state('parent')
+      const child = parent.state('child')
+
+      expect(() => {
+        child.on('TOP', '^^')
+      }).not.toThrow()
+    })
+  })
+
+  describe('Transition execution with strings', () => {
+    it('should resolve string targets correctly', async () => {
+      state1.on('NEXT', 'state2')
+      state2.on('BACK', 'state1')
+      machine.initial(state1)
+
+      const instance = machine.start()
+      expect(instance.current).toBe('state1')
+
+      await instance.send('NEXT')
+      expect(instance.current).toBe('state2')
+
+      await instance.send('BACK')
+      expect(instance.current).toBe('state1')
+    })
+
+    it('should resolve relative paths correctly', async () => {
+      const parent = machine.state('parent')
+      const child1 = parent.state('child1')
+      const child2 = parent.state('child2')
+
+      parent.initial(child1)
+      machine.initial(parent)
+
+      child1.on('SIBLING', '^.child2')
+      child2.on('SIBLING', '^.child1')
+      child2.on('UP', '^')
+
+      const instance = machine.start()
+      expect(instance.current).toBe('parent.child1')
+
+      await instance.send('SIBLING')
+      expect(instance.current).toBe('parent.child2')
+
+      await instance.send('UP')
+      expect(instance.current).toBe('parent.child1') // Re-enters initial child
+    })
+  })
+})

--- a/tests/synchronous-actions.test.js
+++ b/tests/synchronous-actions.test.js
@@ -19,7 +19,7 @@ describe('Synchronous Actions', () => {
       active = machine.state('active')
       actionCalled = false
 
-      idle.on('START', active).do(() => {
+      idle.on('START', 'active').do(() => {
         actionCalled = true
       })
 
@@ -35,7 +35,7 @@ describe('Synchronous Actions', () => {
     it('should execute action before state change', async () => {
       let stateWhenActionRan
 
-      idle.on('CHECK', active).do(() => {
+      idle.on('CHECK', 'active').do(() => {
         stateWhenActionRan = instance.current
       })
 
@@ -57,11 +57,11 @@ describe('Synchronous Actions', () => {
       idle = machine.state('idle')
       counting = machine.state('counting')
 
-      idle.on('INCREMENT', counting).do(ctx => {
+      idle.on('INCREMENT', 'counting').do(ctx => {
         ctx.count = (ctx.count || 0) + 1
       })
 
-      counting.on('INCREMENT', counting).do(ctx => {
+      counting.on('INCREMENT', 'counting').do(ctx => {
         ctx.count++
       })
 
@@ -100,7 +100,7 @@ describe('Synchronous Actions', () => {
       idle = machine.state('idle')
       active = machine.state('active')
 
-      idle.on('COMPUTE', active).do((ctx, event) => {
+      idle.on('COMPUTE', 'active').do((ctx, event) => {
         const result = event.a + event.b
         ctx.result = result
         return { sum: result }
@@ -136,7 +136,7 @@ describe('Synchronous Actions', () => {
       callOrder = []
 
       idle
-        .on('START', active)
+        .on('START', 'active')
         .do(() => {
           callOrder.push('first')
         })
@@ -160,7 +160,7 @@ describe('Synchronous Actions', () => {
       const done = machine.state('done')
 
       active
-        .on('MULTI', done)
+        .on('MULTI', 'done')
         .do(() => ({ a: 1 }))
         .do(() => ({ b: 2 }))
         .do(() => ({ c: 3 }))
@@ -194,7 +194,7 @@ describe('Synchronous Actions', () => {
         actionLog.push({ name: 'update' })
       }
 
-      idle.on('START', active).do(logAction).do(updateAction)
+      idle.on('START', 'active').do(logAction).do(updateAction)
 
       machine.initial(idle)
       instance = machine.start({})
@@ -226,12 +226,12 @@ describe('Synchronous Actions', () => {
       active = machine.state('active')
       error = machine.state('error')
 
-      idle.on('FAIL', active).do(() => {
+      idle.on('FAIL', 'active').do(() => {
         throw new Error('Action failed')
       })
 
       idle
-        .on('SAFE', active)
+        .on('SAFE', 'active')
         .do(ctx => {
           ctx.step1 = true
         })

--- a/tests/transition-guards.test.js
+++ b/tests/transition-guards.test.js
@@ -20,9 +20,9 @@ describe('Transition Guards', () => {
       error = machine.state('error')
 
       // Guard based on context
-      idle.on('START', active).if(ctx => ctx.canStart === true)
+      idle.on('START', 'active').if(ctx => ctx.canStart === true)
 
-      idle.on('START', error).if(ctx => ctx.canStart === false)
+      idle.on('START', 'error').if(ctx => ctx.canStart === false)
 
       machine.initial(idle)
     })
@@ -61,11 +61,11 @@ describe('Transition Guards', () => {
 
       // Guard based on event payload
       pending
-        .on('REVIEW', approved)
+        .on('REVIEW', 'approved')
         .if((ctx, event) => event.decision === 'approve')
 
       pending
-        .on('REVIEW', rejected)
+        .on('REVIEW', 'rejected')
         .if((ctx, event) => event.decision === 'reject')
 
       machine.initial(pending)
@@ -104,11 +104,11 @@ describe('Transition Guards', () => {
       stateC = machine.state('stateC')
 
       // Guards are evaluated in order
-      idle.on('GO', stateA).if(ctx => ctx.priority === 1)
+      idle.on('GO', 'stateA').if(ctx => ctx.priority === 1)
 
-      idle.on('GO', stateB).if(ctx => ctx.priority === 2)
+      idle.on('GO', 'stateB').if(ctx => ctx.priority === 2)
 
-      idle.on('GO', stateC) // No guard - fallback
+      idle.on('GO', 'stateC') // No guard - fallback
 
       machine.initial(idle)
     })
@@ -148,17 +148,17 @@ describe('Transition Guards', () => {
       invalid = machine.state('invalid')
 
       // Complex validation guard
-      form.on('SUBMIT', validating).if(ctx => {
+      form.on('SUBMIT', 'validating').if(ctx => {
         return ctx.form && ctx.form.email && ctx.form.password
       })
 
-      validating.on('VALIDATED', submitting).if(ctx => {
+      validating.on('VALIDATED', 'submitting').if(ctx => {
         const emailValid = /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(ctx.form.email)
         const passwordValid = ctx.form.password.length >= 8
         return emailValid && passwordValid
       })
 
-      validating.on('VALIDATED', invalid).if(ctx => {
+      validating.on('VALIDATED', 'invalid').if(ctx => {
         const emailValid = /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(ctx.form.email)
         const passwordValid = ctx.form.password.length >= 8
         return !emailValid || !passwordValid
@@ -213,7 +213,7 @@ describe('Transition Guards', () => {
       active = machine.state('active')
 
       // Guard that throws error
-      idle.on('START', active).if(() => {
+      idle.on('START', 'active').if(() => {
         throw new Error('Guard error')
       })
 
@@ -244,18 +244,18 @@ describe('Transition Guards', () => {
 
       // Multiple guards on same transition - all must pass
       idle
-        .on('PROCESS', processing)
+        .on('PROCESS', 'processing')
         .if(ctx => ctx.isAuthenticated === true)
         .if(ctx => ctx.hasPermission === true)
         .if(ctx => ctx.quotaAvailable > 0)
 
       // Alternative transition with different guards
       idle
-        .on('PROCESS', error)
+        .on('PROCESS', 'error')
         .if(ctx => ctx.isAuthenticated === true)
         .if(ctx => ctx.hasPermission === false)
 
-      processing.on('DONE', complete)
+      processing.on('DONE', 'complete')
 
       machine.initial(idle)
     })
@@ -326,13 +326,13 @@ describe('Transition Guards', () => {
 
       // Guards using both context and event data
       idle
-        .on('SUBMIT', approved)
+        .on('SUBMIT', 'approved')
         .if(ctx => ctx.isActive === true)
         .if((ctx, event) => event.amount > 0)
         .if((ctx, event) => event.amount <= ctx.maxAmount)
 
       idle
-        .on('SUBMIT', rejected)
+        .on('SUBMIT', 'rejected')
         .if(ctx => ctx.isActive === true)
         .if((ctx, event) => event.amount > ctx.maxAmount)
 
@@ -393,7 +393,7 @@ describe('Transition Guards', () => {
 
       // Premium user flow
       idle
-        .on('ACTIVATE', premium)
+        .on('ACTIVATE', 'premium')
         .if(ctx => ctx.user !== null)
         .if(ctx => ctx.user.verified === true)
         .if(ctx => ctx.user.subscription === 'premium')
@@ -401,14 +401,14 @@ describe('Transition Guards', () => {
 
       // Basic user flow
       idle
-        .on('ACTIVATE', basic)
+        .on('ACTIVATE', 'basic')
         .if(ctx => ctx.user !== null)
         .if(ctx => ctx.user.verified === true)
         .if(ctx => ctx.user.subscription === 'basic')
 
       // Trial user flow
       idle
-        .on('ACTIVATE', trial)
+        .on('ACTIVATE', 'trial')
         .if(ctx => ctx.user !== null)
         .if(ctx => ctx.user.verified === false)
 

--- a/tests/typescript-integration.test.js
+++ b/tests/typescript-integration.test.js
@@ -65,7 +65,7 @@ describe('TypeScript Integration Tests', () => {
     expect(machine.initialState).toBe(state1);
 
     // Test global transitions
-    const globalTransition = machine.on('GLOBAL', state2);
+    const globalTransition = machine.on('GLOBAL', 'state2');
     expect(typeof globalTransition.if).toBe('function');
     expect(typeof globalTransition.do).toBe('function');
     expect(typeof globalTransition.fire).toBe('function');
@@ -100,7 +100,7 @@ describe('TypeScript Integration Tests', () => {
     expect(parent.exitActions.length).toBe(1);
 
     // Test transitions
-    const transition = parent.on('TEST', child);
+    const transition = parent.on('TEST', 'child');
     expect(parent.transitions.has('TEST')).toBe(true);
     expect(parent.getTransitions('TEST')).toContain(transition);
   });
@@ -110,7 +110,7 @@ describe('TypeScript Integration Tests', () => {
     const idle = machine.state('idle');
     const active = machine.state('active');
 
-    idle.on('START', active);
+    idle.on('START', 'active');
     machine.initial(idle);
 
     const instance = machine.start({ count: 0 });
@@ -139,7 +139,7 @@ describe('TypeScript Integration Tests', () => {
     const from = machine.state('from');
     const to = machine.state('to');
 
-    const transition = from.on('TEST', to);
+    const transition = from.on('TEST', 'to');
 
     // Test method chaining
     const chainResult = transition
@@ -170,8 +170,8 @@ describe('TypeScript Integration Tests', () => {
     const state1 = machine.state('state1');
     const state2 = machine.state('state2');
 
-    state1.on('NEXT', state2);
-    state2.on('BACK', state1);
+    state1.on('NEXT', 'state2');
+    state2.on('BACK', 'state1');
     machine.initial(state1);
 
     const instance = machine.start({ step: 0 }, {

--- a/tests/visualization.test.js
+++ b/tests/visualization.test.js
@@ -12,8 +12,8 @@ describe('State Machine Visualization', () => {
     const off = machine.state('off')
     const on = machine.state('on')
 
-    off.on('TOGGLE', on)
-    on.on('TOGGLE', off)
+    off.on('TOGGLE', 'on')
+    on.on('TOGGLE', 'off')
 
     machine.initial(off)
 
@@ -39,10 +39,10 @@ describe('State Machine Visualization', () => {
     const fastForward = playing.state('fast-forward')
 
     // Transitions
-    stopped.on('PLAY', normal)
-    normal.on('FF', fastForward)
-    fastForward.on('NORMAL', normal)
-    playing.on('STOP', stopped)
+    stopped.on('PLAY', 'playing.normal')
+    normal.on('FF', 'fast-forward')
+    fastForward.on('NORMAL', 'normal')
+    playing.on('STOP', 'stopped')
 
     machine.initial(stopped)
 
@@ -54,7 +54,8 @@ describe('State Machine Visualization', () => {
     expect(diagram).toContain('playing_normal("normal")')
     expect(diagram).toContain('playing_fast_forward("fast-forward")')
     expect(diagram).toContain('stopped -->|PLAY| playing_normal')
-    expect(diagram).toContain('playing_normal -->|FF| playing_fast_forward')
+    expect(diagram).toContain('playing_normal -->|FF| fast_forward')
+    expect(diagram).toContain('playing_fast_forward -->|NORMAL| normal')
     expect(diagram).toContain('class stopped initial')
   })
 
@@ -74,10 +75,10 @@ describe('State Machine Visualization', () => {
     const privacy = settings.state('privacy')
 
     // Transitions across levels
-    loggedOut.on('LOGIN', profile)
-    profile.on('SETTINGS', account)
-    account.on('PRIVACY', privacy)
-    loggedIn.on('LOGOUT', loggedOut)
+    loggedOut.on('LOGIN', 'profile')
+    profile.on('SETTINGS', 'account')
+    account.on('PRIVACY', 'privacy')
+    loggedIn.on('LOGOUT', 'logged-out')
 
     machine.initial(loggedOut)
 
@@ -99,9 +100,9 @@ describe('State Machine Visualization', () => {
     const yellow = machine.state('yellow')
     const green = machine.state('green')
 
-    red.on('TIMER', green)
-    green.on('TIMER', yellow)
-    yellow.on('TIMER', red)
+    red.on('TIMER', 'green')
+    green.on('TIMER', 'yellow')
+    yellow.on('TIMER', 'red')
 
     machine.initial(red)
 
@@ -133,11 +134,12 @@ describe('State Machine Visualization', () => {
     const working = active.state('working')
     const paused = active.state('paused')
 
-    idle.on('START', working)
-    working.on('PAUSE', paused)
-    paused.on('RESUME', working)
-    active.on('STOP', idle)
+    idle.on('START', 'active.working')
+    working.on('PAUSE', 'paused')
+    paused.on('RESUME', 'working')
+    active.on('STOP', 'idle')
 
+    active.initial(working)
     machine.initial(idle)
 
     const instance = machine.start()
@@ -166,11 +168,11 @@ describe('State Machine Visualization', () => {
     const state2 = machine.state('state2')
     const error = machine.state('error')
 
-    state1.on('NEXT', state2)
-    state2.on('BACK', state1)
+    state1.on('NEXT', 'state2')
+    state2.on('BACK', 'state1')
 
     // Global transition that works from any state
-    machine.on('ERROR', error)
+    machine.on('ERROR', 'error')
 
     machine.initial(state1)
 
@@ -189,8 +191,8 @@ describe('State Machine Visualization', () => {
     const state2 = machine.state('state.with.dots')
     const state3 = machine.state('state with spaces')
 
-    state1.on('EVENT', state2)
-    state2.on('EVENT', state3)
+    state1.on('EVENT', 'state.with.dots')
+    state2.on('EVENT', 'state with spaces')
 
     machine.initial(state1)
 
@@ -236,8 +238,8 @@ describe('State Machine Visualization', () => {
       const idle = machine.state('idle')
       const active = machine.state('active')
 
-      idle.on('START', active)
-      active.on('STOP', idle)
+      idle.on('START', 'active')
+      active.on('STOP', 'idle')
 
       machine.initial(idle)
     })
@@ -272,8 +274,8 @@ describe('State Machine Visualization', () => {
       const idle = machine.state('idle')
       const active = machine.state('active')
 
-      idle.on('START', active)
-      active.on('STOP', idle)
+      idle.on('START', 'active')
+      active.on('STOP', 'idle')
 
       machine.initial(idle)
       instance = machine.start()

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -168,7 +168,7 @@ export interface InstanceOptions {
 export interface Transition<TContext = BaseContext, TEvent = BaseEvent> {
 
   readonly event: string;
-  readonly target: string | State<TContext> | TargetResolver<TContext, TEvent>;
+  readonly target: string | TargetResolver<TContext, TEvent>;
   readonly source: State<TContext> | null;
 
   /**
@@ -255,7 +255,7 @@ export interface State<TContext = BaseContext> {
    */
   on<TEvent = BaseEvent>(
     event: string,
-    target: string | State<TContext> | TargetResolver<TContext, TEvent>
+    target: string | TargetResolver<TContext, TEvent>
   ): Transition<TContext, TEvent>;
 
   /**
@@ -443,7 +443,7 @@ export interface Machine<TContext = BaseContext> {
    */
   on<TEvent = BaseEvent>(
     event: string,
-    target: string | State<TContext> | TargetResolver<TContext, TEvent>
+    target: string | TargetResolver<TContext, TEvent>
   ): Transition<TContext, TEvent>;
 
   /**


### PR DESCRIPTION
- Remove support for state object references in transitions
- Add validation to reject non-string targets (except functions)
- Update TypeScript definitions for string-only API
- Fix relative state navigation docs (^^ not ^.^)
- Update all examples and tests to use string syntax

BREAKING CHANGE: State transitions must now use string references. Object references like state.on('EVENT', stateObject) are no longer supported. Use string paths like state.on('EVENT', 'stateName') instead.